### PR TITLE
Better support for Fedora (and other RedHat probably)

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -8,7 +8,7 @@ _clone-src() {
 	set -x
 
 	if [[ ! -d "${DIR_SRC}" ]]; then
-		git clone git@github.com:dexonline/dexonline.git "${DIR_SRC}"
+		git clone https://github.com/dexonline/dexonline/ "${DIR_SRC}"
 	fi
 }
 

--- a/make.sh
+++ b/make.sh
@@ -20,6 +20,15 @@ _download-db() {
 	fi
 }
 
+_setup-selinux() {
+    set -x
+
+    if ! command -v getenforce | grep "Enforcing";
+    then
+        sudo chcon -Rt svirt_sandbox_file_t .
+    fi
+}
+
 _update-permissions() {
 	set -x
 
@@ -30,7 +39,8 @@ _update-permissions() {
 		sudo chown 33:33 -R src
 		sudo setfacl -R -m "u:33:rwX,u:${USER}:rwX" src
 		sudo setfacl -dR -m "u:33:rwX,u:${USER}:rwX" src
-	fi
+        _setup-selinux
+    fi
 }
 
 _start-containers() {


### PR DESCRIPTION
Fedora comes with SELinux enabled in "Enforcing" mode and firewalld installed. `make.sh` won't work by default. This PR adds:
1. commands to setup necessary permissions for SELinux
2. commands to add docker's interface to firewalld's trusted list
3. replace "git" protocol with "https" bacause it was failing
```sh
git clone git@github.com:dexonline/dexonline.git
Cloning into 'dexonline'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```