### PR TITLE
Bump PHP version to 7.4

### DIFF
--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.0-apache
+FROM php:7.4-apache
 RUN apt update && apt install -y mysql-client && apt-get clean
 RUN docker-php-ext-install -j$(nproc) gettext mysqli pdo_mysql && a2enmod rewrite
 COPY 000-default.conf /etc/apache2/sites-available/000-default.conf


### PR DESCRIPTION
The project seems to work only with PHP >=7.4 (see because of typed class properties).
Also on my debian 11 i get E: Package 'mysql-client' has no installation candidate. Fixed by replacing with mariadb-client (or default-mysql-client).